### PR TITLE
Annotated Where/AndWhere/OrWhere

### DIFF
--- a/Neo4jClient.DataAnnotations/CypherFluentQueryExtensions`Where.cs
+++ b/Neo4jClient.DataAnnotations/CypherFluentQueryExtensions`Where.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using Neo4jClient.DataAnnotations.Utils;
+using System.Linq.Expressions;
+using System.Linq;
+using Neo4jClient.Cypher;
+using System.Reflection;
+using Neo4jClient.DataAnnotations.Expressions;
+using Neo4jClient.DataAnnotations.Cypher;
+
+namespace Neo4jClient.DataAnnotations//.Cypher
+{
+    public static partial class CypherFluentQueryExtensions
+    {
+
+        #region AndWhere
+        internal static ICypherFluentQuery SharedAndWhere(this ICypherFluentQuery query, LambdaExpression expression)
+        {
+            return SharedProjectionQuery<object>(query, expression, "AND", isOutputQuery: false, applyResultFormat: false);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere(this ICypherFluentQuery query, Expression<Func<object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1>(this ICypherFluentQuery query, Expression<Func<T1, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2>(this ICypherFluentQuery query, Expression<Func<T1, T2, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6, T7>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6, T7, T8>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedAndWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, object>> expression)
+        {
+            return SharedAndWhere(query, expression);
+        }
+        #endregion
+
+        #region OrWhere
+        internal static ICypherFluentQuery SharedOrWhere(this ICypherFluentQuery query, LambdaExpression expression)
+        {
+            return SharedProjectionQuery<object>(query, expression, "OR", isOutputQuery: false, applyResultFormat: false);
+        }
+
+        #endregion
+
+        #region Where
+        internal static ICypherFluentQuery SharedWhere(this ICypherFluentQuery query, LambdaExpression expression)
+        {
+            return SharedProjectionQuery<object>(query, expression, "WHERE", isOutputQuery: false, applyResultFormat: false);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere(this ICypherFluentQuery query, Expression<Func<object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1>(this ICypherFluentQuery query, Expression<Func<T1, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2>(this ICypherFluentQuery query, Expression<Func<T1, T2, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6, T7>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6, T7, T8>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, object>> expression)
+        {
+            return SharedWhere(query, expression);
+        }
+
+
+        #endregion
+    }
+}

--- a/Neo4jClient.DataAnnotations/CypherFluentQueryExtensions`Where.cs
+++ b/Neo4jClient.DataAnnotations/CypherFluentQueryExtensions`Where.cs
@@ -109,7 +109,90 @@ namespace Neo4jClient.DataAnnotations//.Cypher
         {
             return SharedProjectionQuery<object>(query, expression, "OR", isOutputQuery: false, applyResultFormat: false);
         }
+        public static ICypherFluentQuery AnnotatedOrWhere(this ICypherFluentQuery query, Expression<Func<object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
 
+        public static ICypherFluentQuery AnnotatedOrWhere<T1>(this ICypherFluentQuery query, Expression<Func<T1, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2>(this ICypherFluentQuery query, Expression<Func<T1, T2, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6, T7>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6, T7, T8>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
+
+        public static ICypherFluentQuery AnnotatedOrWhere<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this ICypherFluentQuery query, Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, object>> expression)
+        {
+            return SharedOrWhere(query, expression);
+        }
         #endregion
 
         #region Where


### PR DESCRIPTION
While using Neo4jClient i noticed that it doesn't support JsonProperty annotation. This causes a major issue for anyone who uses Neo4jClient.DataAnnotations.
for example: 
Suppose we have a type T1 that has an id field, suppose we have the query below
Where<T1>(a => a.Id == 1) it would be transpiled to WHERE a.Id instead of a.id

I called the functions with Annotated prefix, because Neo4jClient has already reserved the name and as you know extension methods with same signatures as declared methods have least priority in name resolution in C#.

I was inspired by your SharedProjectionQuery function used in the With.

I also added some unit tests.